### PR TITLE
[Feat] StudyCalenderService 내부 전체조회 로직 설계

### DIFF
--- a/back-end/src/main/java/com/studymate/backend/member/domain/Member.java
+++ b/back-end/src/main/java/com/studymate/backend/member/domain/Member.java
@@ -48,7 +48,7 @@ public class Member extends BaseTimeEntity{
     private Set<Authority> authorities;
 
     @OneToMany(mappedBy = "member")
-    private List<StudyCalender> studyCalenders = new ArrayList<>();
+    private final List<StudyCalender> studyCalenders = new ArrayList<>();
 
     public void update(MemberUpdateRequest request) {
         this.name = request.getName();

--- a/back-end/src/main/java/com/studymate/backend/studycalender/controller/StudyCalenderController.java
+++ b/back-end/src/main/java/com/studymate/backend/studycalender/controller/StudyCalenderController.java
@@ -1,6 +1,7 @@
 package com.studymate.backend.studycalender.controller;
 
 import com.studymate.backend.studycalender.dto.CalenderCreateRequest;
+import com.studymate.backend.studycalender.dto.CalenderListResponse;
 import com.studymate.backend.studycalender.dto.CalenderResponse;
 import com.studymate.backend.studycalender.dto.CalenderUpdateRequest;
 import com.studymate.backend.studycalender.service.StudyCalenderService;
@@ -48,5 +49,12 @@ public class StudyCalenderController {
     @ApiResponses(value = @ApiResponse(responseCode = "200", description = "성공"))
     public ResponseEntity<String> deleteCalender(@PathVariable("calender_id") Long id) {
         return ResponseEntity.ok(studyCalenderService.delete(id));
+    }
+
+    @GetMapping("/calender")
+    @Operation(summary = "get members calender", description = "회원이 작성한 스터디 기록을 전체 조회한다.")
+    @ApiResponses(value = @ApiResponse(responseCode = "200", description = "성공"))
+    public ResponseEntity<CalenderListResponse> findAllCalender() {
+        return ResponseEntity.ok(studyCalenderService.findAll());
     }
 }

--- a/back-end/src/main/java/com/studymate/backend/studycalender/service/StudyCalenderService.java
+++ b/back-end/src/main/java/com/studymate/backend/studycalender/service/StudyCalenderService.java
@@ -7,6 +7,7 @@ import com.studymate.backend.studycalender.StudyCalenderRepository;
 import com.studymate.backend.studycalender.StudyCalenderValidator.StudyCalenderValidator;
 import com.studymate.backend.studycalender.domain.StudyCalender;
 import com.studymate.backend.studycalender.dto.CalenderCreateRequest;
+import com.studymate.backend.studycalender.dto.CalenderListResponse;
 import com.studymate.backend.studycalender.dto.CalenderResponse;
 import com.studymate.backend.studycalender.dto.CalenderUpdateRequest;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -80,5 +82,12 @@ public class StudyCalenderService {
 
         studyCalenderRepository.delete(calender);
         return "정상적으로 삭제되었습니다.";
+    }
+
+    public CalenderListResponse findAll() {
+        Member member = memberService.getMember();
+        List<StudyCalender> calenderList = studyCalenderRepository.findAllByMember(member);
+
+        return studyCalenderMapper.toListResponse(calenderList);
     }
 }


### PR DESCRIPTION
## 📢 기능 설명

흐름 : getMember 메서드 사용해서 로그인한 회원 조회 -> StudyCalenderRepository의 쿼리 메소드를 사용해서 List<StudyCalender> 반환 -> StudyMapper클래스를 이용해서 CalenderListResponse 객체로 바꾼 후 반환

<img width="852" alt="스크린샷 2024-02-04 오후 6 54 57" src="https://github.com/TUK2024CD-Studymate/backend/assets/93671010/fcb5a0bf-62fa-43e9-89f8-97ca15e18e65">


<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #24 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
