### PR TITLE
[Feat] 줌 API 구현

### DIFF
--- a/back-end/build.gradle
+++ b/back-end/build.gradle
@@ -56,6 +56,8 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+	implementation 'com.squareup.okhttp3:okhttp:4.9.3'
 }
 
 tasks.named('test') {

--- a/back-end/src/main/java/com/studymate/backend/config/security/SecurityConfig.java
+++ b/back-end/src/main/java/com/studymate/backend/config/security/SecurityConfig.java
@@ -54,20 +54,21 @@ public class SecurityConfig {
                 )
 
                 .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
-                        .requestMatchers("/api/signIn", "api/login").permitAll()
-                        .requestMatchers( "/","/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                                .requestMatchers("/api/signIn", "api/login").permitAll()
+                                .requestMatchers("/api/meeting/**").permitAll()
+                                .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
 //                        .requestMatchers(PathRequest.toH2Console()).permitAll()
-                        .anyRequest().authenticated()
+                                .anyRequest().authenticated()
                 )
-
                 .sessionManagement(sessionManagement -> sessionManagement
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 .headers(headers ->
                         headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
-                        )
+                )
 
-                .with(new JwtSecurityConfig(tokenProvider), customizer -> {});
+                .with(new JwtSecurityConfig(tokenProvider), customizer -> {
+                });
         return http.build();
     }
 }

--- a/back-end/src/main/java/com/studymate/backend/zoom/ZoomTokenRepository.java
+++ b/back-end/src/main/java/com/studymate/backend/zoom/ZoomTokenRepository.java
@@ -1,0 +1,7 @@
+package com.studymate.backend.zoom;
+
+import com.studymate.backend.zoom.domain.ZoomMeeting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ZoomTokenRepository extends JpaRepository<ZoomMeeting, Long> {
+}

--- a/back-end/src/main/java/com/studymate/backend/zoom/controller/ZoomController.java
+++ b/back-end/src/main/java/com/studymate/backend/zoom/controller/ZoomController.java
@@ -1,0 +1,152 @@
+package com.studymate.backend.zoom.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.studymate.backend.zoom.ZoomTokenRepository;
+import com.studymate.backend.zoom.dto.ZoomMeetingObjectDTO;
+import com.studymate.backend.zoom.dto.ZoomMeetingSettingsDTO;
+import com.studymate.backend.zoom.service.ZoomService;
+import com.studymate.backend.zoom.util.DecEncUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import okhttp3.*;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class ZoomController {
+    private final ZoomService zoomService;
+    private final ZoomTokenRepository zoomTokenRepository;
+
+    @RequestMapping(value = "/api/meeting/zoomApi", method = {RequestMethod.GET
+            , RequestMethod.POST})
+    public ResponseEntity<?> googleAsync(HttpServletRequest req,
+                                         @RequestParam(required = false) String code) throws
+            IOException, NoSuchAlgorithmException {
+
+        String zoomUrl = "https://zoom.us/oauth/token";
+        OkHttpClient client = new OkHttpClient();
+        ObjectMapper mapper = new ObjectMapper();
+
+        FormBody formBody = new FormBody.Builder()
+                .add("code", code)
+                .add("redirect_uri", "http://localhost:8080/api/meeting/zoomApi")
+                .add("grant_type", "authorization_code")
+                .add("code_verifier", DecEncUtil.encode(code))
+                .build();
+        Request zoomRequest = new Request.Builder()
+                .url(zoomUrl)
+                .addHeader("Content-Type", "application/x-www-form-urlencoded")
+                .addHeader("Authorization", "Basic " + "OFJGQlVMTDRRV3FrN011TlhOS3dlUTpvMzcxZTFYYnpoNlNrWkFhbzNDQng5SzBCaTNhV3EwTw==")
+                .post(formBody)
+                .build();
+
+        Response zoomResponse = client.newCall(zoomRequest).execute();
+        String zoomText = zoomResponse.body().string();
+
+        mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+
+        Map<String, String> list = mapper.readValue(zoomText, new TypeReference<>() {
+        });
+        String accessToken = list.get("access_token");
+        String refreshToken = list.get("refresh_token");
+        zoomService.saveToken(accessToken, refreshToken);
+        return ResponseEntity.ok().body(list);
+    }
+
+    @GetMapping("api/meeting/create")
+    public ResponseEntity<?> createMeeting() throws IOException {
+
+        isExpired();
+
+        ZoomMeetingObjectDTO zoomMeetingObjectDTO = new ZoomMeetingObjectDTO();
+
+        String apiUrl = "https://api.zoom.us/v2/users/" + "me" + "/meetings";
+
+        ZoomMeetingSettingsDTO settingsDTO = new ZoomMeetingSettingsDTO();
+        settingsDTO.setJoin_before_host(false);
+        settingsDTO.setParticipant_video(true);
+        settingsDTO.setHost_video(false);
+        settingsDTO.setAuto_recording("cloud");
+        settingsDTO.setMute_upon_entry(true);
+        zoomMeetingObjectDTO.setType(1);
+        settingsDTO.setMeeting_authentication(true);
+
+        zoomMeetingObjectDTO.setSettings(settingsDTO);
+
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + zoomService.findAccessToken());
+        headers.add("content-type", "application/json");
+        HttpEntity<ZoomMeetingObjectDTO> httpEntity = new HttpEntity<ZoomMeetingObjectDTO>(zoomMeetingObjectDTO, headers);
+        ResponseEntity<ZoomMeetingObjectDTO> zEntity = restTemplate.exchange(apiUrl, HttpMethod.POST, httpEntity, ZoomMeetingObjectDTO.class);
+        if (zEntity.getStatusCodeValue() == 201) {
+            Map<String, Object> meetCredentials = new HashMap<>();
+            meetCredentials.put("start_url", zEntity.getBody().getStart_url());
+            meetCredentials.put("join_url", zEntity.getBody().getJoin_url());
+            return ResponseEntity.ok().body(meetCredentials);
+        }
+
+        Map<String, Object> meetCredentials = new HashMap<>();
+        meetCredentials.put("start_url", zoomMeetingObjectDTO.getStart_url());
+        meetCredentials.put("join_url", zoomMeetingObjectDTO.getJoin_url());
+        return ResponseEntity.ok().body(meetCredentials);
+    }
+
+    public ResponseEntity<?> refreshToken() throws IOException {
+        String zoomUrl = "https://zoom.us/oauth/token";
+
+        OkHttpClient client = new OkHttpClient();
+        ObjectMapper mapper = new ObjectMapper();
+
+        FormBody formBody = new FormBody.Builder()
+                .add("grant_type", "refresh_token")
+                .add("refresh_token", zoomService.findRefreshToken())
+                .build();
+        Request zoomRequest = new Request.Builder()
+                .url(zoomUrl)
+                .addHeader("Content-Type", "application/x-www-form-urlencoded")
+                .addHeader("Authorization","Basic " + "OFJGQlVMTDRRV3FrN011TlhOS3dlUTpvMzcxZTFYYnpoNlNrWkFhbzNDQng5SzBCaTNhV3EwTw")
+                .post(formBody)
+                .build();
+
+        Response zoomResponse = client.newCall(zoomRequest).execute();
+        String zoomText = zoomResponse.body().string();
+
+        mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+
+        Map<String, String> list = mapper.readValue(zoomText, new TypeReference<>() {});
+        String accessToken = list.get("access_token");
+        String refreshToken = list.get("refresh_token");
+        return ResponseEntity.ok().body(list);
+    }
+    public void isExpired() throws IOException {
+        // 현재 시간 가져오기
+        LocalDateTime now = LocalDateTime.now();
+
+        // updatedAt과 현재 시간의 차이 계산 (단위: 분)
+        long minutesSinceUpdate = ChronoUnit.MINUTES.between(zoomTokenRepository.findById(0L).get().getUpdatedAt(), now);
+
+        // 만료 시간을 60분으로 설정
+        long expirationTimeInMinutes = 60;
+
+        // 현재 시간과 updatedAt의 차이가 expirationTimeInMinutes 이상인 경우 만료되었다고 판단
+        // updatedAt 시간이 현재 시간으로부터 60분 이상 경과했다면 true를 반환하며, 그렇지 않으면 false를 반환합니다.
+        boolean checkExpired = minutesSinceUpdate >= expirationTimeInMinutes;
+        // 토큰 재발급
+        if(checkExpired) {
+            refreshToken();
+        }
+    }
+}

--- a/back-end/src/main/java/com/studymate/backend/zoom/domain/ZoomMeeting.java
+++ b/back-end/src/main/java/com/studymate/backend/zoom/domain/ZoomMeeting.java
@@ -1,0 +1,23 @@
+package com.studymate.backend.zoom.domain;
+
+import com.studymate.backend.global.BaseTimeEntity;
+import com.studymate.backend.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ZoomMeeting extends BaseTimeEntity {
+
+    @Id
+    private Long id;
+
+    @Column(length = 1000)
+    private String accessToken;
+
+    @Column(length = 1000)
+    private String refreshToken;
+}

--- a/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomGlobalDialInNumbersDTO.java
+++ b/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomGlobalDialInNumbersDTO.java
@@ -1,0 +1,28 @@
+package com.studymate.backend.zoom.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+public class ZoomGlobalDialInNumbersDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String country;
+
+    private String country_name;
+
+    private String city;
+
+    private String number;
+
+    private String type;
+    @Override
+    public String toString() {
+        return "ZoomGlobalDialInNumbersDTO [city=" + getCity() + ", country=" + getCountry() + ", country_name=" + getCountry_name()
+                + ", number=" + getNumber() + ", type=" + getType() + "]";
+    }
+}

--- a/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomInterpreterDTO.java
+++ b/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomInterpreterDTO.java
@@ -1,0 +1,22 @@
+package com.studymate.backend.zoom.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+public class ZoomInterpreterDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public String email;
+
+    public String languages;
+
+    @Override
+    public String toString() {
+        return "ZoomInterpreterDTO [email=" + getEmail() + ", languages=" + getLanguages() + "]";
+    }
+
+}

--- a/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomMeetingObjectDTO.java
+++ b/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomMeetingObjectDTO.java
@@ -1,0 +1,80 @@
+package com.studymate.backend.zoom.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Getter
+@Setter
+public class ZoomMeetingObjectDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+
+    private String uuid;
+
+    private String assistant_id;
+
+    private String host_email;
+
+    private String registration_url;
+
+    private String topic;
+
+    private Integer type;
+
+    private String start_time;
+
+    private Integer duration;
+
+    private String schedule_for;
+
+    private String timezone;
+
+    private String created_at;
+
+    private String password;
+
+    private Boolean default_password;
+
+    public Boolean getDefault_password() {
+        return default_password;
+    }
+
+    public void setDefault_password(Boolean default_password) {
+        this.default_password = default_password;
+    }
+
+    private String agenda;
+
+    private String start_url;
+
+    private String join_url;
+
+    private String h323_password;
+
+    private Integer pmi;
+
+    private ZoomMeetingRecurrenceDTO recurrence;
+
+    private List<ZoomMeetingTrackingFieldsDTO> tracking_fields;
+
+    private List<ZoomMeetingOccurenceDTO> occurrences;
+
+    private ZoomMeetingSettingsDTO settings;
+
+    @Override
+    public String toString() {
+        return "ZoomMeetingObjectDTO [agenda=" + agenda + ", assistant_id=" + assistant_id + ", created_at="
+                + created_at + ", duration=" + duration + ", h323_password=" + h323_password + ", host_email="
+                + host_email + ", id=" + id + ", join_url=" + join_url + ", occurrences=" + occurrences + ", password="
+                + password + ", pmi=" + pmi + ", recurrence=" + recurrence + ", registration_url=" + registration_url
+                + ", schedule_for=" + schedule_for + ", settings=" + settings + ", start_time=" + start_time
+                + ", start_url=" + start_url + ", timezone=" + timezone + ", topic=" + topic + ", tracking_fields="
+                + tracking_fields + ", type=" + type + ", uuid=" + uuid + "]";
+    }
+
+}

--- a/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomMeetingOccurenceDTO.java
+++ b/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomMeetingOccurenceDTO.java
@@ -1,0 +1,28 @@
+package com.studymate.backend.zoom.dto;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+public class ZoomMeetingOccurenceDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String occurrence_id;
+
+    private String start_time;
+
+    private Integer duration;
+
+    private String status;
+
+    @Override
+    public String toString() {
+        return "ZoomMeetingOccurenceDTO [duration=" + getDuration() + ", occurrence_id=" + getOccurrence_id() + ", start_time="
+                + getStart_time() + ", status=" + getStatus() + "]";
+    }
+}

--- a/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomMeetingRecurrenceDTO.java
+++ b/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomMeetingRecurrenceDTO.java
@@ -1,0 +1,38 @@
+package com.studymate.backend.zoom.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ZoomMeetingRecurrenceDTO {
+    private static final long serialVersionUID = 1L;
+
+    private Integer type;
+
+    private Integer repeat_interval;
+
+    private String weekly_days;
+
+    private Integer monthly_day;
+
+    private Integer monthly_week;
+
+    private Integer monthly_week_day;
+
+    private Integer end_times;
+
+    private String end_date_time;
+
+    public Integer getType() {
+        return type;
+    }
+
+    @Override
+    public String toString() {
+        return "ZoomMeetingRecurrenceDTO [end_date_time=" + end_date_time + ", end_times=" + end_times
+                + ", monthly_day=" + monthly_day + ", monthly_week=" + monthly_week + ", monthly_week_day="
+                + monthly_week_day + ", repeat_interval=" + repeat_interval + ", type=" + type + ", weekly_days="
+                + weekly_days + "]";
+    }
+}

--- a/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomMeetingSettingsDTO.java
+++ b/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomMeetingSettingsDTO.java
@@ -1,0 +1,91 @@
+package com.studymate.backend.zoom.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Getter
+@Setter
+public class ZoomMeetingSettingsDTO implements Serializable{
+    private static final long serialVersionUID = 1L;
+
+    private Boolean host_video;
+
+    private Boolean participant_video;
+
+    private Boolean cn_meeting;
+
+    private Boolean in_meeting;
+
+    private Boolean join_before_host;
+
+    private Boolean mute_upon_entry;
+
+    private Boolean watermark;
+
+    private Boolean use_pmi;
+
+    private Integer approval_type;
+
+    private Integer registration_type;
+
+    private String audio;
+
+    private String auto_recording;
+
+    private String alternative_hosts;
+
+    private Boolean close_registration;
+
+    private Boolean waiting_room;
+
+    List<String> global_dial_in_countries;
+
+    List<ZoomGlobalDialInNumbersDTO> global_dial_in_numbers;
+
+    private Boolean registrants_email_notification;
+
+    private String contact_name;
+
+    private String contact_email;
+
+    private Boolean registrants_confirmation_email;
+
+    private Boolean meeting_authentication;
+
+    private String authentication_option;
+
+    private String authenticated_domains;
+
+    private String authentication_name;
+
+    private Boolean show_share_button;
+
+    private Boolean allow_multiple_devices;
+
+    private String encryption_type;
+
+    private List<String> meeting_invitees;
+
+    public List<ZoomInterpreterDTO> interpreters;
+
+    @Override
+    public String toString() {
+        return "ZoomMeetingSettingsDTO [allow_multiple_devices=" + allow_multiple_devices + ", alternative_hosts="
+                + alternative_hosts + ", approval_type=" + approval_type + ", audio=" + audio
+                + ", authenticated_domains=" + authenticated_domains + ", authentication_name=" + authentication_name
+                + ", authentication_option=" + authentication_option + ", auto_recording=" + auto_recording
+                + ", close_registration=" + close_registration + ", cn_meeting=" + cn_meeting + ", contact_email="
+                + contact_email + ", contact_name=" + contact_name + ", encryption_type=" + encryption_type
+                + ", global_dial_in_countries=" + global_dial_in_countries + ", global_dial_in_numbers="
+                + global_dial_in_numbers + ", host_video=" + host_video + ", in_meeting=" + in_meeting
+                + ", interpreters=" + interpreters + ", join_before_host=" + join_before_host
+                + ", meeting_authentication=" + meeting_authentication + ", mute_upon_entry=" + mute_upon_entry
+                + ", participant_video=" + participant_video + ", registrants_confirmation_email="
+                + registrants_confirmation_email + ", registrants_email_notification=" + registrants_email_notification
+                + ", registration_type=" + registration_type + ", show_share_button=" + show_share_button + ", use_pmi="
+                + use_pmi + ", waiting_room=" + waiting_room + ", watermark=" + watermark + "]";
+    }
+}

--- a/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomMeetingTrackingFieldsDTO.java
+++ b/back-end/src/main/java/com/studymate/backend/zoom/dto/ZoomMeetingTrackingFieldsDTO.java
@@ -1,0 +1,20 @@
+package com.studymate.backend.zoom.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ZoomMeetingTrackingFieldsDTO {
+    public String field;
+
+    public String value;
+
+    public Boolean visible;
+
+
+    @Override
+    public String toString() {
+        return "ZoomMeetingTrackingFieldsDTO [field=" + getField() + ", value=" + getValue() + ", visible=" + getVisible() + "]";
+    }
+}

--- a/back-end/src/main/java/com/studymate/backend/zoom/service/ZoomService.java
+++ b/back-end/src/main/java/com/studymate/backend/zoom/service/ZoomService.java
@@ -1,0 +1,42 @@
+package com.studymate.backend.zoom.service;
+
+import com.studymate.backend.zoom.ZoomTokenRepository;
+import com.studymate.backend.zoom.domain.ZoomMeeting;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ZoomService {
+
+    private final ZoomTokenRepository zoomTokenRepository;
+
+    @Transactional
+    public void saveToken(String accessToken, String refreshToken) {
+
+
+        ZoomMeeting zoomMeeting = ZoomMeeting.builder()
+                .id(0L)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+        zoomTokenRepository.save(zoomMeeting);
+    }
+
+    @Transactional
+    public String findAccessToken() {
+
+        String accessToken = zoomTokenRepository.findById(0L).get().getAccessToken();
+
+        return accessToken;
+    }
+
+    @Transactional
+    public String findRefreshToken() {
+        String refreshToken = zoomTokenRepository.findById(0L).get().getRefreshToken();
+
+        return refreshToken;
+    }
+}

--- a/back-end/src/main/java/com/studymate/backend/zoom/util/DecEncUtil.java
+++ b/back-end/src/main/java/com/studymate/backend/zoom/util/DecEncUtil.java
@@ -1,0 +1,20 @@
+package com.studymate.backend.zoom.util;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+@Component
+public class DecEncUtil {
+
+    public static String encode(final String clearText) throws NoSuchAlgorithmException {
+        return new String(
+                Base64.getEncoder().encode(MessageDigest.getInstance("SHA-256").digest(
+                        clearText.getBytes(StandardCharsets.UTF_8)
+                ))
+        );
+    }
+}


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
**줌 api 사용을 위한 인증, 토큰 발급 api
미팅 서비스를 이용하기 위한 미팅 URL 발급 api** 

흐름
<img width="1165" alt="스크린샷 2024-02-12 오전 2 37 16" src="https://github.com/TUK2024CD-Studymate/backend/assets/93671010/aa39c688-f614-4d93-a4c0-a2ad642d4e4d">
서버실행 후 클라이언트는 이 URL에 접속한다.

<img width="1464" alt="스크린샷 2024-02-12 오전 2 37 52" src="https://github.com/TUK2024CD-Studymate/backend/assets/93671010/489bc525-3920-4144-8085-d5d88aa7498c">
그 후 바디 데이터에 토큰과 엑세스 토큰이 출력된다.

<img width="1281" alt="스크린샷 2024-02-12 오전 2 38 41" src="https://github.com/TUK2024CD-Studymate/backend/assets/93671010/e68726ed-de45-47ad-8f87-eb28b178cbd1">
토큰은 DB에 저장 후 api호출을 위해 보관한다.

<img width="897" alt="스크린샷 2024-02-12 오전 2 39 09" src="https://github.com/TUK2024CD-Studymate/backend/assets/93671010/b375a679-a74d-404c-9277-214ae3a90be1">
회의 생성을 위해 위와같은 엔트포인트를 적는다.

<img width="911" alt="스크린샷 2024-02-12 오전 2 39 29" src="https://github.com/TUK2024CD-Studymate/backend/assets/93671010/025da2b4-7156-4f70-be8f-b39599ce3b98">
서버에서 미팅 생성을 위한 바디데이터, 헤더에 토큰 및 형식을 담아서 줌 api에 요청을 보낸 후 참가 url과 생성 url을 바디 데이터에 전송한다.


<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #40 
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
