### PR TITLE
[Fix] StudyCalenderDTO에 날짜 역직렬화, 직렬화 추가 적용

### DIFF
--- a/back-end/src/main/java/com/studymate/backend/studycalender/dto/CalenderCreateRequest.java
+++ b/back-end/src/main/java/com/studymate/backend/studycalender/dto/CalenderCreateRequest.java
@@ -1,6 +1,9 @@
 package com.studymate.backend.studycalender.dto;
 
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.studymate.backend.member.domain.Interests;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -9,8 +12,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-
 import java.time.LocalDateTime;
 
 @Getter
@@ -23,15 +24,20 @@ public class CalenderCreateRequest {
     @NotBlank
     @Schema(description = "스터디 내용", nullable = false, example = "일차함수란 무엇인가? 수학에서 일차 함수(一次函數, 영어: linear function)는 최고 차수가 1 이하인 다항 함수이다. 즉, 그래프가 직선인 함수이다. 정비례 함수(正比例函數 영어: directly proportional function)는 일차 함수에 상수항이 0이라는 조건을 추가한 특수한 경우이다. 즉, 그래프가 원점을 지나는 직선인 함수이다. 단, 계수는 실수여야 한다.")
     private String content;
+
     @NotNull
     @Schema(description = "스터디 분류", nullable = false, example = "MATH")
     private Interests studyClass;
-    @Schema(description = "스터디 시작 시간", nullable = false, example = "2024-01-25T18:30:49.224Z")
+
     @NotNull
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+    @Schema(description = "스터디 시작 시간", nullable = false, example = "2024-02-13 13:50")
     private LocalDateTime startTime;
-    @Schema(description = "스터디 시작 시간", nullable = false, example = "2024-01-25T20:30:49.224Z")
+
     @NotNull
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @Schema(description = "스터디 종료 시간", nullable = false, example = "2024-02-13 15:50")
     private LocalDateTime endTime;
 }

--- a/back-end/src/main/java/com/studymate/backend/studycalender/dto/CalenderResponse.java
+++ b/back-end/src/main/java/com/studymate/backend/studycalender/dto/CalenderResponse.java
@@ -1,5 +1,6 @@
 package com.studymate.backend.studycalender.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.studymate.backend.member.domain.Interests;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,7 +17,9 @@ public class CalenderResponse {
 
     private Interests studyClass;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime startTime;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime endTime;
 }

--- a/back-end/src/main/java/com/studymate/backend/studycalender/dto/CalenderUpdateRequest.java
+++ b/back-end/src/main/java/com/studymate/backend/studycalender/dto/CalenderUpdateRequest.java
@@ -1,5 +1,8 @@
 package com.studymate.backend.studycalender.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.studymate.backend.member.domain.Interests;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -8,7 +11,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
@@ -28,12 +30,14 @@ public class CalenderUpdateRequest {
     private Interests interests;
 
     @NotNull
-    @Schema(description = "스터디 시작 시간", nullable = false, example = "2024-01-25T18:30:49.224Z")
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @Schema(description = "스터디 시작 시간", nullable = false, example = "2024-02-13 15:10")
     private LocalDateTime startTime;
 
-    @Schema(description = "스터디 시작 시간", nullable = false, example = "2024-01-25T20:30:49.224Z")
     @NotNull
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @Schema(description = "스터디 종료 시간", nullable = false, example = "2024-02-13 17:50")
     private LocalDateTime endTime;
 }


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부

요청 데이터 예시
<img width="858" alt="스크린샷 2024-02-14 오후 11 29 15" src="https://github.com/TUK2024CD-Studymate/backend/assets/93671010/785cb34d-929b-4adb-9a35-4a036de7f41f">

반환 데이터 예시
<img width="848" alt="스크린샷 2024-02-14 오후 11 29 38" src="https://github.com/TUK2024CD-Studymate/backend/assets/93671010/5cde9b0a-ff4f-40e5-bfde-a483dd10f55e">


<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #58 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
